### PR TITLE
Moved to libadalang 23 + followed changes

### DIFF
--- a/alire.toml
+++ b/alire.toml
@@ -1,6 +1,6 @@
 name = "dependency_graph_extractor"
 description = "Extract dependency information from Ada projects"
-version = "22.0.0"
+version = "23.0.0"
 licenses = "BSD-3-Clause"
 website = "https://github.com/TNO/Dependency_Graph_Extractor-Ada"
 tags = ["extract", "dependency", "analysis", "graph", "graphml"]
@@ -12,4 +12,4 @@ maintainers-logins = ["pjljvandelaar"]
 executables = ["dependency_graph_extractor"]
 
 [[depends-on]]
-libadalang = "^22.0.0"
+libadalang = "^23.0.0"

--- a/src/extraction-primitive_subps.adb
+++ b/src/extraction-primitive_subps.adb
@@ -4,14 +4,13 @@ with Extraction.Utilities;
 package body Extraction.Primitive_Subps is
 
    use type LAL.Analysis_Unit;
-   use type LALCO.Ada_Node_Kind_Type;
 
    procedure Extract_Nodes
      (Node : LAL.Ada_Node'Class; Graph : Graph_Operations.Graph_Context)
    is
    begin
       if Utilities.Is_Relevant_Basic_Decl (Node)
-        and then Node.Kind = LALCO.Ada_Type_Decl
+        and then Node.Kind in LALCO.Ada_Type_Decl
       then
          declare
             Type_Decl  : constant LAL.Type_Decl        := Node.As_Type_Decl;
@@ -34,7 +33,7 @@ package body Extraction.Primitive_Subps is
    is
    begin
       if Utilities.Is_Relevant_Basic_Decl (Node)
-        and then Node.Kind = LALCO.Ada_Type_Decl
+        and then Node.Kind in LALCO.Ada_Type_Decl
       then
          declare
             Type_Decl  : constant LAL.Type_Decl        := Node.As_Type_Decl;

--- a/tests/syntax_examples/alire.toml
+++ b/tests/syntax_examples/alire.toml
@@ -1,7 +1,7 @@
 name = "syntax_examples"
 description = "Analysis and manipulation of Ada code based on concrete patterns"
-version = "22.0.0"
+version = "23.0.0"
 licenses = "BSD-3-Clause"
 
 [[depends-on]]
-rejuvenation = "^22.0.0"
+rejuvenation = "^23.0.0"


### PR DESCRIPTION
Since libadalang 23, the Ada_Type_Decl is no longer an enumeration value of Ada_Node_Kind_Type, but an enumeration range thereof:

      subtype Ada_Type_Decl is Ada_Node_Kind_Type
            range Ada_Anonymous_Type_Decl .. Ada_Formal_Type_Decl;

This enumeration range includes the following 4 values:

	Ada_Anonymous_Type_Decl, Ada_Synth_Anonymous_Type_Decl, Ada_Concrete_Type_Decl, and Ada_Formal_Type_Decl

This change of libadalang results in errors like
```
extraction-primitive_subps.adb:14:35: error: invalid use of subtype mark in expression or call
```

This pull request fixes these issues.