### PR TITLE
Move to Libadalang24

### DIFF
--- a/alire.toml
+++ b/alire.toml
@@ -1,6 +1,6 @@
 name = "dependency_graph_extractor"
 description = "Extract dependency information from Ada projects"
-version = "23.0.0"
+version = "24.0.0"
 licenses = "BSD-3-Clause"
 website = "https://github.com/TNO/Dependency_Graph_Extractor-Ada"
 tags = ["extract", "dependency", "analysis", "graph", "graphml"]
@@ -12,4 +12,4 @@ maintainers-logins = ["pjljvandelaar"]
 executables = ["dependency_graph_extractor"]
 
 [[depends-on]]
-libadalang = "^23.0.0"
+libadalang = "^24.0.0"

--- a/alire.toml
+++ b/alire.toml
@@ -1,6 +1,6 @@
 name = "dependency_graph_extractor"
 description = "Extract dependency information from Ada projects"
-version = "22.0.0"
+version = "23.0.0"
 licenses = "BSD-3-Clause"
 website = "https://github.com/TNO/Dependency_Graph_Extractor-Ada"
 tags = ["extract", "dependency", "analysis", "graph", "graphml"]
@@ -12,4 +12,4 @@ maintainers-logins = ["pjljvandelaar"]
 executables = ["dependency_graph_extractor"]
 
 [[depends-on]]
-libadalang = "^22.0.0"
+libadalang = "^23.0.0"

--- a/src/extraction-bodies_for_entries.adb
+++ b/src/extraction-bodies_for_entries.adb
@@ -23,8 +23,8 @@ package body Extraction.Bodies_For_Entries is
             Accept_Stmt : constant LAL.Accept_Stmt := Node.As_Accept_Stmt;
             Task_Body   : constant LAL.Basic_Decl  :=
               Utilities.Get_Parent_Basic_Decl (Accept_Stmt);
-            Entry_Decl : constant LAL.Basic_Decl :=
-              Utilities.Get_Referenced_Decl (Accept_Stmt.F_Name);
+            Entry_Decl : constant LAL.Entry_Decl :=
+              Accept_Stmt.P_Corresponding_Entry;
          begin
             Graph.Write_Edge
               (Entry_Decl, Task_Body,

--- a/src/extraction-primitive_subps.adb
+++ b/src/extraction-primitive_subps.adb
@@ -4,14 +4,13 @@ with Extraction.Utilities;
 package body Extraction.Primitive_Subps is
 
    use type LAL.Analysis_Unit;
-   use type LALCO.Ada_Node_Kind_Type;
 
    procedure Extract_Nodes
      (Node : LAL.Ada_Node'Class; Graph : Graph_Operations.Graph_Context)
    is
    begin
       if Utilities.Is_Relevant_Basic_Decl (Node)
-        and then Node.Kind = LALCO.Ada_Type_Decl
+        and then Node.Kind in LALCO.Ada_Type_Decl
       then
          declare
             Type_Decl  : constant LAL.Type_Decl        := Node.As_Type_Decl;
@@ -34,7 +33,7 @@ package body Extraction.Primitive_Subps is
    is
    begin
       if Utilities.Is_Relevant_Basic_Decl (Node)
-        and then Node.Kind = LALCO.Ada_Type_Decl
+        and then Node.Kind in LALCO.Ada_Type_Decl
       then
          declare
             Type_Decl  : constant LAL.Type_Decl        := Node.As_Type_Decl;


### PR DESCRIPTION
Libadalang 24 no longer supports `F_Name` for an `Accept_Stmt`.

This results in errors like
```
extraction-bodies_for_entries.adb:27:57: error: no selector "F_Name" for private type "Accept_Stmt" defined at libadalang-analysis.ads:300
```

Libadalang does support `P_corresponding_Entry`, hence we don't need to look up the corresponding declaration ourselves via `F_Name`.

This pull request solves these issues, and makes DGE compatible with libadalang 24.
 