### PR TITLE
Move to Libadalang25

### DIFF
--- a/.github/workflows/ada.yml
+++ b/.github/workflows/ada.yml
@@ -15,6 +15,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: alire-project/setup-alire@v4
+    - name: Private dependencies on windows - workaround for https://github.com/alire-project/alire/issues/1762
+      if: startsWith(matrix.os, 'windows')
+      run: alr settings --set dependencies.shared false
     - name: Build
       run: alr build
 

--- a/.github/workflows/ada.yml
+++ b/.github/workflows/ada.yml
@@ -13,8 +13,8 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: alire-project/setup-alire@v1
+    - uses: actions/checkout@v4
+    - uses: alire-project/setup-alire@v4
     - name: Build
       run: alr build
 
@@ -26,7 +26,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: alire-project/setup-alire@v1
+    - uses: actions/checkout@v4
+    - uses: alire-project/setup-alire@v4
     - name: Example project to analyze
       run: cd tests/syntax_examples && alr build

--- a/.github/workflows/ada.yml
+++ b/.github/workflows/ada.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - uses: alire-project/setup-alire@v3
+    - uses: alire-project/setup-alire@v2
     - name: Build
       run: alr build
 
@@ -27,6 +27,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - uses: alire-project/setup-alire@v3
+    - uses: alire-project/setup-alire@v2
     - name: Example project to analyze
       run: cd tests/syntax_examples && alr build

--- a/.github/workflows/ada.yml
+++ b/.github/workflows/ada.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - uses: alire-project/setup-alire@v4
+    - uses: alire-project/setup-alire@v3
     - name: Build
       run: alr build
 
@@ -27,6 +27,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - uses: alire-project/setup-alire@v4
+    - uses: alire-project/setup-alire@v3
     - name: Example project to analyze
       run: cd tests/syntax_examples && alr build

--- a/.github/workflows/ada.yml
+++ b/.github/workflows/ada.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - uses: alire-project/setup-alire@v2
+    - uses: alire-project/setup-alire@v4
     - name: Build
       run: alr build
 
@@ -27,6 +27,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - uses: alire-project/setup-alire@v2
+    - uses: alire-project/setup-alire@v4
     - name: Example project to analyze
       run: cd tests/syntax_examples && alr build

--- a/alire.toml
+++ b/alire.toml
@@ -1,9 +1,9 @@
 name = "dependency_graph_extractor"
 description = "Extract dependency information from Ada projects"
-version = "24.0.0"
+version = "25.0.0"
 licenses = "BSD-3-Clause"
 website = "https://github.com/TNO/Dependency_Graph_Extractor-Ada"
-tags = ["extract", "dependency", "analysis", "graph", "graphml"]
+tags = ["extract", "dependency", "analysis", "graph", "graphml", "ada"]
 
 authors = ["Jeroen Ketema", "Pierre van de Laar"]
 maintainers = ["Pierre van de Laar <pierre.van.de.laar@gmail.com>"]
@@ -12,4 +12,4 @@ maintainers-logins = ["pjljvandelaar"]
 executables = ["dependency_graph_extractor"]
 
 [[depends-on]]
-libadalang = "^24.0.0"
+libadalang = "^25.0.0"

--- a/alire.toml
+++ b/alire.toml
@@ -1,6 +1,6 @@
 name = "dependency_graph_extractor"
 description = "Extract dependency information from Ada projects"
-version = "23.0.0"
+version = "24.0.0"
 licenses = "BSD-3-Clause"
 website = "https://github.com/TNO/Dependency_Graph_Extractor-Ada"
 tags = ["extract", "dependency", "analysis", "graph", "graphml"]
@@ -12,4 +12,4 @@ maintainers-logins = ["pjljvandelaar"]
 executables = ["dependency_graph_extractor"]
 
 [[depends-on]]
-libadalang = "^23.0.0"
+libadalang = "^24.0.0"

--- a/alire.toml
+++ b/alire.toml
@@ -1,6 +1,6 @@
 name = "dependency_graph_extractor"
 description = "Extract dependency information from Ada projects"
-version = "22.0.0"
+version = "23.0.0"
 licenses = "BSD-3-Clause"
 website = "https://github.com/TNO/Dependency_Graph_Extractor-Ada"
 tags = ["extract", "dependency", "analysis", "graph", "graphml"]
@@ -12,4 +12,4 @@ maintainers-logins = ["pjljvandelaar"]
 executables = ["dependency_graph_extractor"]
 
 [[depends-on]]
-libadalang = "^22.0.0"
+libadalang = "^23.0.0"

--- a/src/dependency_graph_extractor.adb
+++ b/src/dependency_graph_extractor.adb
@@ -1,5 +1,6 @@
 with Ada.Calendar;
 with Ada.Command_Line;
+with Ada.Exceptions;
 with Ada.Strings.Unbounded;
 with Ada.Text_IO;
 with GNATCOLL.VFS;
@@ -55,6 +56,13 @@ begin
    end;
 
    Ada.Text_IO.Put_Line
-     (Ada.Text_IO.Standard_Error,
+     ("Success in " &
       Duration'Image (Ada.Calendar.Clock - Start_Time));
+
+exception
+   when E : others =>
+      Ada.Text_IO.Put_Line (Ada.Text_IO.Standard_Error, "Error occurred");
+      Ada.Text_IO.Put_Line (Ada.Text_IO.Standard_Error,
+                            Ada.Exceptions.Exception_Message (E));
+      raise;
 end Dependency_Graph_Extractor;

--- a/src/extraction-bodies_for_entries.adb
+++ b/src/extraction-bodies_for_entries.adb
@@ -23,8 +23,8 @@ package body Extraction.Bodies_For_Entries is
             Accept_Stmt : constant LAL.Accept_Stmt := Node.As_Accept_Stmt;
             Task_Body   : constant LAL.Basic_Decl  :=
               Utilities.Get_Parent_Basic_Decl (Accept_Stmt);
-            Entry_Decl : constant LAL.Basic_Decl :=
-              Utilities.Get_Referenced_Decl (Accept_Stmt.F_Name);
+            Entry_Decl : constant LAL.Entry_Decl :=
+              Accept_Stmt.P_Corresponding_Entry;
          begin
             Graph.Write_Edge
               (Entry_Decl, Task_Body,

--- a/src/extraction-decl_types.adb
+++ b/src/extraction-decl_types.adb
@@ -100,6 +100,7 @@ package body Extraction.Decl_Types is
               Get_Subp_Spec (Source_Decl);
          begin
             if Source_Decl.Kind /= LALCO.Ada_Enum_Literal_Decl
+              and then Source_Decl.Kind /= LALCO.Ada_Synthetic_Char_Enum_Lit
               and then not Subp_Spec.Is_Null
             then
                declare

--- a/src/extraction-decl_types.adb
+++ b/src/extraction-decl_types.adb
@@ -15,7 +15,8 @@ package body Extraction.Decl_Types is
          return
            Get_Subp_Spec
              (Utilities.Get_Referenced_Decl
-                (Basic_Decl.As_Generic_Subp_Renaming_Decl.F_Renames));
+                (Basic_Decl.As_Generic_Subp_Renaming_Decl.F_Renames.
+                       F_Renamed_Object));
       else
          return Basic_Decl.P_Subp_Spec_Or_Null (Follow_Generic => True);
       end if;

--- a/src/extraction-graph_operations.adb
+++ b/src/extraction-graph_operations.adb
@@ -191,13 +191,15 @@ package body Extraction.Graph_Operations is
         GW.Attribute_Value_Sets.Empty)
    is
    begin
-      if Target_Decl.P_Defining_Names'Length = 1 then
-         Graph.Write_Edge
-           (Source_Name, Source_Decl, Target_Decl.P_Defining_Name, Target_Decl,
-            Edge_Ty, Edge_Attrs);
-      else
-         raise Internal_Extraction_Error
-           with "Target declaration with single defining name expected";
+      if not Target_Decl.Is_Null then
+         if Target_Decl.P_Defining_Names'Length = 1 then
+            Graph.Write_Edge
+              (Source_Name, Source_Decl, Target_Decl.P_Defining_Name,
+               Target_Decl, Edge_Ty, Edge_Attrs);
+         else
+            raise Internal_Extraction_Error
+              with "Target declaration with single defining name expected";
+         end if;
       end if;
    end Write_Edge;
 

--- a/src/extraction-node_edge_types.adb
+++ b/src/extraction-node_edge_types.adb
@@ -216,7 +216,7 @@ package body Extraction.Node_Edge_Types is
             --  Packages.
          when LALCO.Ada_Package_Decl | LALCO.Ada_Package_Body_Stub |
            LALCO.Ada_Package_Body | LALCO.Ada_Package_Renaming_Decl |
-           LALCO.Ada_Generic_Package_Decl          |
+           LALCO.Ada_Generic_Package_Decl |
            LALCO.Ada_Generic_Package_Instantiation |
            LALCO.Ada_Generic_Package_Renaming_Decl =>
             return Node_Type_Ada_Package_Declaration;
@@ -232,12 +232,13 @@ package body Extraction.Node_Edge_Types is
            LALCO.Ada_Subp_Body_Stub | LALCO.Ada_Generic_Subp_Decl |
            LALCO.Ada_Generic_Subp_Instantiation |
            LALCO.Ada_Generic_Subp_Renaming_Decl |
-           LALCO.Ada_Abstract_Formal_Subp_Decl  |
-           LALCO.Ada_Concrete_Formal_Subp_Decl  =>
+           LALCO.Ada_Abstract_Formal_Subp_Decl |
+           LALCO.Ada_Concrete_Formal_Subp_Decl =>
             return Node_Type_Ada_Subprogram_Declaration;
          when LALCO.Ada_Entry_Decl | LALCO.Ada_Entry_Body =>
             return Node_Type_Ada_Entry_Declaration;
-         when LALCO.Ada_Enum_Literal_Decl =>
+         when LALCO.Ada_Enum_Literal_Decl |
+           LALCO.Ada_Synthetic_Char_Enum_Lit =>
             return Node_Type_Ada_Enum_Literal_Declaration;
             --  Tasks.
          when LALCO.Ada_Task_Type_Decl | LALCO.Ada_Task_Body_Stub |
@@ -245,7 +246,7 @@ package body Extraction.Node_Edge_Types is
             return Node_Type_Ada_Task_Declaration;
             --  Types.
          when LALCO.Ada_Type_Decl | LALCO.Ada_Subtype_Decl |
-           LALCO.Ada_Incomplete_Type_Decl        |
+           LALCO.Ada_Incomplete_Type_Decl |
            LALCO.Ada_Incomplete_Tagged_Type_Decl =>
             return Node_Type_Ada_Type_Declaration;
          when others =>

--- a/src/extraction-node_edge_types.adb
+++ b/src/extraction-node_edge_types.adb
@@ -225,7 +225,8 @@ package body Extraction.Node_Edge_Types is
            LALCO.Ada_Protected_Body | LALCO.Ada_Single_Protected_Decl =>
             return Node_Type_Ada_Protected_Declaration;
             --  Subprograms.
-         when LALCO.Ada_Abstract_Subp_Decl | LALCO.Ada_Subp_Decl |
+         when LALCO.Ada_Abstract_Subp_Decl | LALCO.Ada_Synthetic_Subp_Decl |
+           LALCO.Ada_Subp_Decl |
            LALCO.Ada_Expr_Function | LALCO.Ada_Null_Subp_Decl |
            LALCO.Ada_Subp_Body | LALCO.Ada_Subp_Renaming_Decl |
            LALCO.Ada_Subp_Body_Stub | LALCO.Ada_Generic_Subp_Decl |

--- a/src/extraction-primitive_subps.adb
+++ b/src/extraction-primitive_subps.adb
@@ -4,14 +4,13 @@ with Extraction.Utilities;
 package body Extraction.Primitive_Subps is
 
    use type LAL.Analysis_Unit;
-   use type LALCO.Ada_Node_Kind_Type;
 
    procedure Extract_Nodes
      (Node : LAL.Ada_Node'Class; Graph : Graph_Operations.Graph_Context)
    is
    begin
       if Utilities.Is_Relevant_Basic_Decl (Node)
-        and then Node.Kind = LALCO.Ada_Type_Decl
+        and then Node.Kind in LALCO.Ada_Type_Decl
       then
          declare
             Type_Decl  : constant LAL.Type_Decl        := Node.As_Type_Decl;
@@ -34,7 +33,7 @@ package body Extraction.Primitive_Subps is
    is
    begin
       if Utilities.Is_Relevant_Basic_Decl (Node)
-        and then Node.Kind = LALCO.Ada_Type_Decl
+        and then Node.Kind in LALCO.Ada_Type_Decl
       then
          declare
             Type_Decl  : constant LAL.Type_Decl        := Node.As_Type_Decl;

--- a/src/extraction-renamings.adb
+++ b/src/extraction-renamings.adb
@@ -31,11 +31,13 @@ package body Extraction.Renamings is
             return
               Basic_Decl.As_Package_Renaming_Decl.F_Renames.F_Renamed_Object;
          when LALCO.Ada_Generic_Package_Renaming_Decl =>
-            return Basic_Decl.As_Generic_Package_Renaming_Decl.F_Renames;
+            return Basic_Decl.As_Generic_Package_Renaming_Decl.F_Renames.
+              F_Renamed_Object;
          when LALCO.Ada_Subp_Renaming_Decl =>
             return Basic_Decl.As_Subp_Renaming_Decl.F_Renames.F_Renamed_Object;
          when LALCO.Ada_Generic_Subp_Renaming_Decl =>
-            return Basic_Decl.As_Generic_Subp_Renaming_Decl.F_Renames;
+            return Basic_Decl.As_Generic_Subp_Renaming_Decl.F_Renames.
+              F_Renamed_Object;
          when LALCO.Ada_Exception_Decl =>
             return Basic_Decl.As_Exception_Decl.F_Renames.F_Renamed_Object;
          when LALCO.Ada_Object_Decl =>

--- a/tests/syntax_examples/src/main.adb
+++ b/tests/syntax_examples/src/main.adb
@@ -174,9 +174,11 @@ procedure Main is
                      or else Node.As_Identifier.P_Referenced_Decl.Kind = Ada_Generic_Subp_Instantiation
                      or else Node.As_Identifier.P_Referenced_Decl.Kind = Ada_Subp_Body_Stub
                      or else Node.As_Identifier.P_Referenced_Decl.Kind = Ada_Abstract_Subp_Decl
+                     or else Node.As_Identifier.P_Referenced_Decl.Kind = Ada_Synthetic_Subp_Decl
                      or else Node.As_Identifier.P_Referenced_Decl.Kind = Ada_Abstract_Formal_Subp_Decl
                      or else Node.As_Identifier.P_Referenced_Decl.Kind = Ada_Concrete_Formal_Subp_Decl
-                     or else Node.As_Identifier.P_Referenced_Decl.Kind = Ada_Enum_Literal_Decl) -- Enum literals are parameterless functions
+                     or else Node.As_Identifier.P_Referenced_Decl.Kind = Ada_Enum_Literal_Decl -- Enum literals are parameterless functions
+                     or else Node.As_Identifier.P_Referenced_Decl.Kind = Ada_Synthetic_Char_Enum_Lit)
            and then (Rejuvenation.Navigation.Get_Ancestor_Of_Type(Node, Ada_Generic_Package_Instantiation) = No_Ada_Node -- Skip designator in instantiation
                      or else Rejuvenation.Navigation.Get_Ancestor_Of_Type(Node, Ada_Param_Assoc) = No_Ada_Node
                      or else Rejuvenation.Navigation.Get_Ancestor_Of_Type(Node, Ada_Param_Assoc).As_Param_Assoc.F_Designator /= Node)


### PR DESCRIPTION
`F_Renames` of Generic (Package | Subp) Renaming Decl[arations] no longer returns a `Name` but a `Renaming_Clause`.

This change caused the following errors
```
extraction-decl_types.adb:18:58: error: expected type "Name'Class" defined at libadalang-analysis.ads:285
extraction-decl_types.adb:18:58: error: found private type "Renaming_Clause" defined at libadalang-analysis.ads:2833
extraction-renamings.adb:34:63: error: expected private type "Name" defined at libadalang-analysis.ads:285
extraction-renamings.adb:34:63: error: found private type "Renaming_Clause" defined at libadalang-analysis.ads:2833
extraction-renamings.adb:38:60: error: expected private type "Name" defined at libadalang-analysis.ads:285
extraction-renamings.adb:38:60: error: found private type "Renaming_Clause" defined at libadalang-analysis.ads:2833
```

The `Name` of a `Renaming Clause` can be obtained using `F_Renamed_Object`.

This pull request fixes these errors.